### PR TITLE
Add association test for Post model

### DIFF
--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "belongs to a user" do
+    assoc = described_class.reflect_on_association(:user)
+    expect(assoc.macro).to eq(:belongs_to)
+  end
 end


### PR DESCRIPTION
## Summary
- add rspec test to verify Post belongs to a user

## Testing
- `bundle exec rspec spec/models/post_spec.rb` *(fails: Bundler::Dsl::DSLError: error parsing Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846f8e72958832db27716888cbb6725